### PR TITLE
Handle database initialization file error

### DIFF
--- a/Bot-Trading_Swing.py
+++ b/Bot-Trading_Swing.py
@@ -14275,8 +14275,10 @@ class EnhancedTradingBot:
             # Create database file path
             db_path = "trading_bot.db"
             
-            # Ensure directory exists
-            os.makedirs(os.path.dirname(db_path), exist_ok=True)
+            # Ensure directory exists (only if db_path contains a directory)
+            db_dir = os.path.dirname(db_path)
+            if db_dir:  # Only create directory if path contains one
+                os.makedirs(db_dir, exist_ok=True)
             
             # Connect to database
             self.conn = sqlite3.connect(db_path)


### PR DESCRIPTION
Modify `_init_database` to conditionally create directories to fix `[Errno 2] No such file or directory: ''`.

The error occurred because `os.path.dirname("trading_bot.db")` returns an empty string, causing `os.makedirs("")` to fail. The fix ensures `os.makedirs` is only called if a directory component exists in the database path.

---
<a href="https://cursor.com/background-agent?bcId=bc-b1e68d7c-a3a6-4191-b96d-75e779c21bee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b1e68d7c-a3a6-4191-b96d-75e779c21bee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

